### PR TITLE
Replace Parser::getFunctionLang() with ::getTargetLanguage()

### DIFF
--- a/includes/LuaLibrary/LuaLibBCmath.php
+++ b/includes/LuaLibrary/LuaLibBCmath.php
@@ -27,7 +27,7 @@ class LuaLibBCmath extends Scribunto_LuaLibraryBase {
 		];
 		$langCode = 'en';
 		if ( $this->getParser() ) {
-			$langCode = $this->getParser()->getFunctionLang();
+			$langCode = $this->getParser()->getTargetLanguage();
 		}
 		return $this->getEngine()->registerInterface( __DIR__ . '/lua/non-pure/BCmath.lua', $lib, [
 			'lang' => $langCode,


### PR DESCRIPTION
Parser::getFunctionLang() is being deprecated.  These two functions
have been identical since 7df3473cfea59df53debb7a9eefffed8a7f20fb3
in MW 1.19 (2012) and this extension already requires MW >= 1.33.

Bug: T318860
